### PR TITLE
Pokedex fix and enhancements

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,12 +65,16 @@ async def on_message(message):
       msg = get_random_quote('./gandalfQuotes.json').format(message)
       await message.channel.send(str(client.get_emoji(917135652171161681)) + " Gandalf: " + msg)
 
-  if random.randrange(1, int(os.environ['pokemonSpawnRate'])) == 1:
+  #if random.randrange(1, int(os.environ['pokemonSpawnRate'])) == 1:
+  pokerand = random.randrange(1, int(os.environ['pokemonSpawnRate'])) 
+  if pokerand == 1:
+    print("main - Triggered pokemon spawn")
     await spawnPokemon(message)     
 
   await mongoDBAPI.insertMessage("Messages", "TNNGBOT", "JacobTEST", message)
 
 async def spawnPokemon(message, pokemon_number=None, catch_count=None):
+  print("main - Prepping pokemon spawn")
   if pokemon_number is None:
     pokePool: list[int] = []
     with open('./pokemonPool.json', 'r') as pokePoolJson:
@@ -275,7 +279,7 @@ async def pokedex(
       total_caught = len(fresh)
       unique_count = len(name_counts.keys())
       duplicates_total = sum(max(0, c - 1) for c in name_counts.values())
-      totals_line = f"Total Caught: {total_caught}, Unique: {unique_count}, Duplicates: {duplicates_total}"
+      totals_line = f"Total Caught: `{total_caught}`, Unique: `{unique_count}`, Duplicates: `{duplicates_total}`"
       # Apply duplicates filter again
       mode = (dupe_mode or duplicates)
       if mode == "hide":
@@ -407,7 +411,7 @@ async def pokedex(
           self.parent_view.page_index = min(max(0, idx), self.parent_view.total_pages - 1)
           self.parent_view.last_loaded = now_eastern_str()
           self.parent_view._sync_buttons()
-          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded), view=self.parent_view)
+          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded, self.parent_view.totals_line), view=self.parent_view)
 
       class DuplicatesSelect(discord.ui.Select):
         def __init__(self, parent_view: 'PokedexView'):
@@ -446,7 +450,7 @@ async def pokedex(
           for opt in self.options:
             opt.default = (opt.value == mode)
           self.parent_view._sync_buttons()
-          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded), view=self.parent_view)
+          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded, self.parent_view.totals_line), view=self.parent_view)
 
       class SortSelect(discord.ui.Select):
         def __init__(self, parent_view: 'PokedexView'):
@@ -482,7 +486,7 @@ async def pokedex(
             if isinstance(child, discord.ui.Select) and getattr(child, 'placeholder', '') == "Jump to page":
               child.options = [discord.SelectOption(label=f"Page {i+1}", value=str(i)) for i in range(self.parent_view.total_pages)]
           self.parent_view._sync_buttons()
-          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded), view=self.parent_view)
+          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded, self.parent_view.totals_line), view=self.parent_view)
 
       class DirectionSelect(discord.ui.Select):
         def __init__(self, parent_view: 'PokedexView'):
@@ -517,7 +521,7 @@ async def pokedex(
             if isinstance(child, discord.ui.Select) and getattr(child, 'placeholder', '') == "Jump to page":
               child.options = [discord.SelectOption(label=f"Page {i+1}", value=str(i)) for i in range(self.parent_view.total_pages)]
           self.parent_view._sync_buttons()
-          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded), view=self.parent_view)
+          await interaction.response.edit_message(content=render_page(self.parent_view.rows, self.parent_view.page_index, self.parent_view.page_size, self.parent_view.last_loaded, self.parent_view.totals_line), view=self.parent_view)
 
       async def on_timeout(self) -> None:
         # Disable all controls when view times out

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ async def on_ready():
   print('We have logged in as {0.user}'.format(client))
   print(f"pokemonSpawnRates = {os.environ['pokemonSpawnRate']}")
   print(f"pokemonMaxAttempts = {os.environ['pokemonMaxAttempts']}")
+
   try:
     synced = await client.tree.sync()
     print(f'Synced {len(synced)} command(s)')
@@ -65,16 +66,12 @@ async def on_message(message):
       msg = get_random_quote('./gandalfQuotes.json').format(message)
       await message.channel.send(str(client.get_emoji(917135652171161681)) + " Gandalf: " + msg)
 
-  #if random.randrange(1, int(os.environ['pokemonSpawnRate'])) == 1:
-  pokerand = random.randrange(1, int(os.environ['pokemonSpawnRate'])) 
-  if pokerand == 1:
-    print("main - Triggered pokemon spawn")
+  if random.randrange(1, int(os.environ['pokemonSpawnRate'])) == 1:
     await spawnPokemon(message)     
 
   await mongoDBAPI.insertMessage("Messages", "TNNGBOT", "JacobTEST", message)
 
 async def spawnPokemon(message, pokemon_number=None, catch_count=None):
-  print("main - Prepping pokemon spawn")
   if pokemon_number is None:
     pokePool: list[int] = []
     with open('./pokemonPool.json', 'r') as pokePoolJson:
@@ -260,7 +257,9 @@ async def pokedex(
       counts = Counter(p["number"] for p in caught_pokemon)
       caught_pokemon = [p for p in caught_pokemon if counts[p["number"]] > 1]
     # Build paginated view/UI components
-    header = f"   {'No.':<5} {'Name':<15} {'Caught On'}\n" + ("-" * 49) + "\n"
+    # header = f"   {'No.':<5} {'Name':<15} {'Caught On'}\n" + ("-" * 49) + "\n"
+    # Shrink the table width for mobile users
+    header = f"{'No.':<3} {'Name':<11} {'Caught On'}\n" + ("-" * 39) + "\n"
     local_tz = pytz.timezone("US/Eastern")
 
     prefix = f"**{interaction.user.display_name}'s Pokedex**\n"
@@ -300,7 +299,9 @@ async def pokedex(
         dt = datetime.fromisoformat(p["caught_at"]) if "caught_at" in p and p["caught_at"] else datetime.now()
         dt_local = dt.astimezone(local_tz)
         formatted_date = dt_local.strftime("%m/%d/%Y %I:%M %p")
-        rows_local.append(f"◓  {p['number']:<5} {p['name'].capitalize():<15} {formatted_date} EST\n")
+        # rows_local.append(f"◓  {p['number']:<5} {p['name'].capitalize():<15} {formatted_date} EST\n")
+        # Shrink the table width for mobile users
+        rows_local.append(f"{p['number']:<3} {p['name'].capitalize():<11} {formatted_date} EST\n")
       return rows_local, totals_line
 
     # Initial rows


### PR DESCRIPTION
# Summary of Changes
1. Fixed issue with pokedex response reaching Discord's limit of 2,000 characters per message
2. Converted the simple tabular message to a embed with UI components allowing for pagination, sorting, filtering duplicates, and reloading the displayed information.
3. Added a timestamp that indicates when the data was last loaded.
4. Added totals at the top of the message that indicate the total number of caught, unique, and duplicate pokemon.
5. Reduced table width to prevent line wrapping for mobile users

<img width="500" height="724" alt="image" src="https://github.com/user-attachments/assets/d1491918-8658-4ff5-a438-fd0e6d4cd97e" />
