### PR TITLE
fix trading bug

### DIFF
--- a/tnngbot/db/pokemon.py
+++ b/tnngbot/db/pokemon.py
@@ -73,6 +73,11 @@ class PokemonService(BaseService):
         )
         return result.matched_count == 1
 
+    def get_pokemon_by_id(self, pokemon_id) -> Optional[PokemonDoc]:
+        obj_id = ObjectId(pokemon_id) if not isinstance(pokemon_id, ObjectId) else pokemon_id
+        pokemon: Optional[PokemonDoc] = self.col.find_one({"_id": obj_id})
+        return pokemon
+
     def get_caught_pokemon(self, user: User | Member, sort_by: str = "number", ascending: bool = True) -> List[PokemonDoc]:
         # Convert boolean into pymongo sort direction
         sort_direction = 1 if ascending else -1
@@ -110,4 +115,3 @@ class PokemonService(BaseService):
         pokemon: Optional[PokemonDoc] = self.col.find_one(query)
 
         return pokemon if pokemon and pokemon.get("caught", False) else None
-


### PR DESCRIPTION
tnngbot/cogs/commands/trade_pokemon.py – Trade acceptance now reloads the specific Pokémon documents (via _id) that were originally selected, ensuring the exact level copy is transferred and aborting if ownership changed. Added _get_pokemon_for_trade helper plus refreshed self.my_pokemon/self.for_pokemon before updating ownership, so duplicate-name trades no longer grab a different copy.

tnngbot/db/pokemon.py – Introduced get_pokemon_by_id to fetch a Pokémon document directly via its Mongo _id, allowing the trade flow (and any future features) to precisely re-fetch the intended Pokémon even when multiple copies share the same number.